### PR TITLE
fix: TypeError wrt Instructor-Large

### DIFF
--- a/codeqai/embeddings.py
+++ b/codeqai/embeddings.py
@@ -39,7 +39,7 @@ class Embeddings:
                 except ImportError:
                     self._install_instructor_embedding()
 
-                self.embeddings = HuggingFaceInstructEmbeddings()
+                self.embeddings = HuggingFaceEmbeddings()
 
     def _install_sentence_transformers(self):
         question = [


### PR DESCRIPTION
### With the changes I made,
`$ codeqai search`
 
### worked just fine with "**Instructor-Large**" embedding model

Closes #34 